### PR TITLE
Always check when debug_assertions is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,9 @@ This crate is designed for this purpose.
 
 peace_lock is a drop-in replacement for std/parking_lot's `Mutex` and `RwLock`.
 
-Add `peace_lock = { version = "0.1", features = ["check"]}` to your Cargo.toml
-to enable the check mode. In the check mode, calling `write` or `read` will just
-panic in case of contention. This let's you know the scheduling algorithm has a
-bug!
+Add `peace_lock = "0.1"` to your Cargo.toml. In a debug build, the check mode is
+enabled, and calling `write` or `read` will just panic in case of contention.
+This lets you know the scheduling algorithm has a bug!
 
 
 ```rust
@@ -115,9 +114,9 @@ thread::spawn(|| { *shared_map.get(&1).unwrap().lock() = 3; });
 thread::spawn(|| { *shared_map.get(&2).unwrap().lock() = 4; });
 ```
 
-If you want to squeeze the performance, you can disable the check by remove it
-from the feature list: `peace_lock = { version = "0.1", features = [] }`. This 
-will make the lock zero-cost.
+In a release build, the checks are by default omitted. This 
+will make the lock zero-cost. You can explicitly turn on
+the check mode by adding the `check` feature to the feature list (e.g. `peace_lock = { version = "0.1", features = ["check"] }`).
 
 ## Optional Features
 

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -2,7 +2,7 @@
 use owning_ref::StableAddress;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-#[cfg(feature = "check")]
+#[cfg(any(debug_assertions, feature = "check"))]
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::{
     cell::UnsafeCell,
@@ -13,7 +13,7 @@ use std::{
 /// A mutual exclusive lock
 #[derive(Debug)]
 pub struct Mutex<T: ?Sized> {
-    #[cfg(feature = "check")]
+    #[cfg(any(debug_assertions, feature = "check"))]
     state: AtomicBool,
     value: UnsafeCell<T>,
 }
@@ -43,7 +43,7 @@ impl<T> Mutex<T> {
     #[inline]
     pub fn new(val: T) -> Self {
         Self {
-            #[cfg(feature = "check")]
+            #[cfg(any(debug_assertions, feature = "check"))]
             state: AtomicBool::new(false),
             value: UnsafeCell::new(val),
         }
@@ -83,7 +83,7 @@ where
     #[inline]
     pub fn lock<'a>(&'a self) -> MutexGuard<'a, T> {
         if !self.lock_exclusive() {
-            #[cfg(feature = "check")]
+            #[cfg(any(debug_assertions, feature = "check"))]
             panic!("The lock is already write locked")
         }
 
@@ -92,27 +92,27 @@ where
 
     #[inline]
     fn lock_exclusive(&self) -> bool {
-        #[cfg(feature = "check")]
+        #[cfg(any(debug_assertions, feature = "check"))]
         {
             self.state
                 .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
                 .is_ok()
         }
 
-        #[cfg(not(feature = "check"))]
+        #[cfg(not(any(debug_assertions, feature = "check")))]
         true
     }
 
     #[inline]
     fn unlock_exclusive(&self) -> bool {
-        #[cfg(feature = "check")]
+        #[cfg(any(debug_assertions, feature = "check"))]
         {
             self.state
                 .compare_exchange(true, false, Ordering::Acquire, Ordering::Relaxed)
                 .is_ok()
         }
 
-        #[cfg(not(feature = "check"))]
+        #[cfg(not(any(debug_assertions, feature = "check")))]
         true
     }
 }

--- a/tests/mutex.rs
+++ b/tests/mutex.rs
@@ -19,7 +19,7 @@ fn lock_unlock_lock() {
 }
 
 #[test]
-#[should_panic]
+#[cfg_attr(any(debug_assertions, feature = "check"), should_panic)]
 fn double_lock() {
     let val = Mutex::new(1);
     thread::scope(|s| {

--- a/tests/rwlock.rs
+++ b/tests/rwlock.rs
@@ -19,7 +19,7 @@ fn write_lock_unlock_lock() {
 }
 
 #[test]
-#[should_panic]
+#[cfg_attr(any(debug_assertions, feature = "check"), should_panic)]
 fn double_write_lock() {
     let val = RwLock::new(1);
     thread::scope(|s| {
@@ -36,7 +36,7 @@ fn double_write_lock() {
 }
 
 #[test]
-#[should_panic]
+#[cfg_attr(any(debug_assertions, feature = "check"), should_panic)]
 fn read_write_lock_conflict1() {
     let val = RwLock::new(1);
     thread::scope(|s| {
@@ -53,7 +53,7 @@ fn read_write_lock_conflict1() {
 }
 
 #[test]
-#[should_panic]
+#[cfg_attr(any(debug_assertions, feature = "check"), should_panic)]
 fn read_write_lock_conflict2() {
     let val = RwLock::new(1);
     thread::scope(|s| {


### PR DESCRIPTION
The PR changes the condition for the check mode to `#[cfg(any(debug_assertions, feature = "check"))]`. It also changes some tests so that they should only expect panic if the check mode is turned on.

Closes https://github.com/dovahcrow/peace-lock/issues/3.